### PR TITLE
use faucets asset-url to allow asset fingerprinting

### DIFF
--- a/faucet.config.dev.js
+++ b/faucet.config.dev.js
@@ -35,5 +35,11 @@ module.exports = {
       source: './src/styles/index.scss',
       target: './dist/css/uba-bootstrap-theme.css'
     }
-  ]
+  ],
+  manifest: {
+    target: "./dist/manifest.json",
+    key: "short",
+    baseURI: "../",
+    webRoot: "./dist"
+  },
 }

--- a/faucet.config.js
+++ b/faucet.config.js
@@ -14,5 +14,11 @@ module.exports = {
       source: './src/styles/index.scss',
       target: './dist/css/uba-bootstrap-theme.css'
     }
-  ]
+  ],
+  manifest: {
+    target: "./dist/manifest.json",
+    key: "short",
+    baseURI: "../",
+    webRoot: "./dist"
+  },
 }

--- a/src/styles/_fonts.scss
+++ b/src/styles/_fonts.scss
@@ -1,27 +1,27 @@
 @font-face {
 	font-family: 'MetaCompPro-Normal';
-	src: url('../fonts/MetaWebPro-Normal.eot?#iefix') format('embedded-opentype'), url('../fonts/MetaWebPro-Normal.woff') format('woff');
+	src: asset-url('MetaWebPro-Normal.eot') format('embedded-opentype'), asset-url('MetaWebPro-Normal.woff') format('woff');
 	font-weight: normal;
 	font-style: normal;
 }
 
 @font-face {
 	font-family: 'MetaCompPro-Bold';
-	src: url('../fonts/MetaWebPro-Bold.eot?#iefix') format('embedded-opentype'), url('../fonts/MetaWebPro-Bold.woff') format('woff');
+	src: asset-url('MetaWebPro-Bold.eot') format('embedded-opentype'), asset-url('MetaWebPro-Bold.woff') format('woff');
 	font-weight: normal;
 	font-style: normal;
 }
 
 @font-face {
 	font-family: 'MetaSerifComp-Bold';
-	src: url('../fonts/MetaSerifWeb-Bold.eot?#iefix') format('embedded-opentype'), url('../fonts/MetaSerifWeb-Bold.woff') format('woff');
+	src: asset-url('MetaSerifWeb-Bold.eot') format('embedded-opentype'), asset-url('MetaSerifWeb-Bold.woff') format('woff');
 	font-weight: normal;
 	font-style: normal;
 }
 
 @font-face {
 	font-family: 'MetaSerifComp-Medium';
-  	src: url('../fonts/MetaSerifWeb-Medium.eot?#iefix') format('embedded-opentype'), url('../fonts/MetaSerifWeb-Medium.woff') format('woff');
+	src: asset-url('MetaSerifWeb-Medium.eot') format('embedded-opentype'), asset-url('MetaSerifWeb-Medium.woff') format('woff');
 	font-weight: normal;
 	font-style: normal;
 }

--- a/src/styles/overrides/_cards.scss
+++ b/src/styles/overrides/_cards.scss
@@ -7,7 +7,7 @@
   padding: 1rem 1.25rem .5rem 1.25rem;
 
   &.featured {
-    background-image: url("../images/bg-highlight.png");
+    background-image: asset-url("bg-highlight.png");
     background: linear-gradient(to right,rgba(255,255,255,0) 0%,#5ead35 40%,#5ead35 100%);
   }
 

--- a/src/styles/overrides/_lists.scss
+++ b/src/styles/overrides/_lists.scss
@@ -1,6 +1,6 @@
 .list-group-item {
   &:disabled,
   &.disabled {
-    background-image: url('../images/bg-box-pattern.png');
+    background-image: asset-url('bg-box-pattern.png');
   }
 }

--- a/src/styles/overrides/_navbar.scss
+++ b/src/styles/overrides/_navbar.scss
@@ -7,10 +7,10 @@
 .navbar {
   border-bottom: 10px solid $uba-blue;
   &.bg-dark {
-    background-image: url('../images/bg-header-pattern.png');
+    background-image: asset-url('bg-header-pattern.png');
   }
   &.bg-light {
-    background-image: url('../images/bg-box-pattern.png');
+    background-image: asset-url('bg-box-pattern.png');
    }
 
   &.navbar-light .navbar-nav .nav-link {

--- a/src/styles/overrides/_sitemap.scss
+++ b/src/styles/overrides/_sitemap.scss
@@ -11,7 +11,7 @@
   border-bottom: none;
   padding-top: 2rem;
   padding-bottom: 1rem;
-  background-image: url('../images/bg-box-pattern.png');
+  background-image: asset-url('bg-box-pattern.png');
 
   a {
     color: $uba-gray;

--- a/src/styles/overrides/_typography.scss
+++ b/src/styles/overrides/_typography.scss
@@ -4,7 +4,7 @@
 
 h1, h2, h3 {
   font-family: 'MetaSerifComp-Medium';
-	src: url('../fonts/MetaSerifWeb-Medium.eot?#iefix') format('embedded-opentype'), url('../fonts/MetaSerifWeb-Medium.woff') format('woff');
+  src: asset-url('MetaSerifWeb-Medium.eot') format('embedded-opentype'), asset-url('MetaSerifWeb-Medium.woff') format('woff');
 
   margin-bottom: .5rem;
 }


### PR DESCRIPTION
This PR introduces usage of faucets `asset-url` instead of referencing relative asset paths in SASS files. This allows an app which uses this styleguide to activate asset fingerprinting using faucet asset pipeline. Generated bundles in `/dist` still uses relative paths resolved by `asset-url` sass function (except `?#iefix` font suffix which is only necessary for <=IE8 and bootstrap 4 doesn't support it ether).